### PR TITLE
Decoder input dropout using random codes; codec manifest tweak

### DIFF
--- a/create_input_manifest_for_codecextraction.py
+++ b/create_input_manifest_for_codecextraction.py
@@ -2,6 +2,7 @@ import glob
 import soundfile as sf
 import json
 import argparse
+import os
 
 def write_manifest(manifest_path, records):
     with open(manifest_path, 'w') as f:
@@ -27,9 +28,14 @@ def main():
     wav_files = [ f for f in wav_files ]
     print("Found {} wav files in {}".format(len(wav_files), data_dir))
     records = []
+    skipped = []
     for aidx, audio_file in enumerate(wav_files):
         if aidx % 100 == 0:
             print("Processed {} files out of {}".format(aidx, len(wav_files)))
+        if not os.access(audio_file, os.R_OK):
+            print(f"Could not read {audio_file}. Skipping...")
+            skipped.append(audio_file)
+            continue
         audio_duration = sf.info(audio_file).duration
         record = {
             'audio_filepath' : audio_file,
@@ -41,6 +47,9 @@ def main():
         }
         records.append(record)
     
+    if len(skipped) > 0:
+        print(f"\nSkipped {len(skipped)} files that were not readable.\n    ")
+
     if len(records) > 0:
         write_manifest(manifest_path, records)
 

--- a/nemo/collections/tts/models/speechllm/megatron_base_speechllm_prompt_model.py
+++ b/nemo/collections/tts/models/speechllm/megatron_base_speechllm_prompt_model.py
@@ -322,6 +322,7 @@ class MegatronBaseSpeechLM(MegatronBaseModel, TextGeneration):
                 num_workers=self.cfg.data.num_workers,
                 pin_memory=True,
                 dropout_decoder_input_ids=self.cfg.data.get('dropout_decoder_input_ids', 0.0), # Only dropout for training
+                dropout_decoder_input_use_random=self.cfg.data.get('dropout_decoder_input_use_random', False)
             )
         elif self.cfg.data.get('train_manifest', None):
             self._train_ds, self._train_dl = self.build_virtual_prompt_tarred_dataset(

--- a/nemo/collections/tts/models/speechllm/megatron_t5_speechllm_model.py
+++ b/nemo/collections/tts/models/speechllm/megatron_t5_speechllm_model.py
@@ -1471,7 +1471,7 @@ class MegatronT5SpeechLMModel(MegatronBaseSpeechLM):
             json.dump(average_metrics, f)
 
     def build_virtual_prompt_dataset(
-        self, dataset_paths, batch_size, for_train, drop_last, shuffle, num_workers, pin_memory, dropout_decoder_input_ids=0.0,
+        self, dataset_paths, batch_size, for_train, drop_last, shuffle, num_workers, pin_memory, dropout_decoder_input_ids=0.0, dropout_decoder_input_use_random=False
     ):
         dataset = T5SpeechLMDataset(
             datasets=dataset_paths,
@@ -1525,6 +1525,7 @@ class MegatronT5SpeechLMModel(MegatronBaseSpeechLM):
             phoneme_probability=self.cfg.data.get('phoneme_probability', 0.5),
             encoder_type=self.cfg.data.get('encoder_type', 'single_transformer'),
             dropout_decoder_input_ids=dropout_decoder_input_ids,
+            dropout_decoder_input_use_random=dropout_decoder_input_use_random,
             speech_mask_token=self.cfg.data.get('speech_mask_token', 0),
         )
 


### PR DESCRIPTION
This PR contains two changes:

1. **Decoder input dropout using random codes (experimental)**
Adding a flavor of decoder input dropout: instead of replacing the dropped-out input token with a mask token, replace it with a random token taken from the codec codebooks. The idea is to teach the decode not to fully trust past tokens even if they are not specifically a mask token, which is the case at inference. To enable, set:
`+model.data.dropout_decoder_random_id=true`

2. A tweak to the script that creates manifests for codec extraction: skip unreadable files and report it.

