### PR TITLE
Bugfix in DPO Pareto ranking

### DIFF
--- a/scripts/t5tts/dpo/create_preference_pairs.py
+++ b/scripts/t5tts/dpo/create_preference_pairs.py
@@ -123,6 +123,8 @@ def pareto_rank(items):
     # A helper function to check if item A is dominated by item B
     # A: (cerA, ssimA), B: (cerB, ssimB)
     def is_dominated(A, B):
+        assert len(A) == 2
+        assert len(B) == 2        
         return (B[0] <= A[0]) and (B[1] >= A[1]) and (B != A)
         # Equivalently, check at least one strict inequality:
         # (B[0] < A[0]) or (B[1] > A[1])
@@ -142,7 +144,7 @@ def pareto_rank(items):
             dominated = False
             for j in range(len(remaining)):
                 if i != j:
-                    if is_dominated(remaining[i], remaining[j]):
+                    if is_dominated(remaining[i][:2], remaining[j][:2]):
                         dominated = True
                         break
             if not dominated:


### PR DESCRIPTION
Bugfix for an infinite loop in DPO preference pair creation.

The `is_dominated()` check in Pareto ranking has a condition that checks that `B != A`. However if B and A are tuples that contain more than just metrics (e.g. the `item_idx`) then that comparison isn't working as intended.

Fixing by only feeding the metrics portion of the tuple (indices 0, 1) into `is_dominated()`.

@Shehzeen to review please - thank you